### PR TITLE
Fix warnings 

### DIFF
--- a/plugins/json-api/models/attachment.php
+++ b/plugins/json-api/models/attachment.php
@@ -11,7 +11,7 @@ class JSON_API_Attachment {
   var $parent;      // Integer
   var $mime_type;   // String
   
-  function JSON_API_Attachment($wp_attachment = null) {
+  function __construct($wp_attachment = null) {
     if ($wp_attachment) {
       $this->import_wp_object($wp_attachment);
       if ($this->is_image()) {

--- a/plugins/json-api/models/author.php
+++ b/plugins/json-api/models/author.php
@@ -15,7 +15,7 @@ class JSON_API_Author {
   //   JSON_API_Author objects can include additional values by using the
   //   author_meta query var.
   
-  function JSON_API_Author($id = null) {
+  function __construct($id = null) {
     if ($id) {
       $this->id = (int) $id;
     } else {

--- a/plugins/json-api/models/category.php
+++ b/plugins/json-api/models/category.php
@@ -9,7 +9,7 @@ class JSON_API_Category {
   var $parent;      // Integer
   var $post_count;  // Integer
   
-  function JSON_API_Category($wp_category = null) {
+  function __construct($wp_category = null) {
     if ($wp_category) {
       $this->import_wp_object($wp_category);
     }

--- a/plugins/json-api/models/comment.php
+++ b/plugins/json-api/models/comment.php
@@ -10,7 +10,7 @@ class JSON_API_Comment {
   var $parent;  // Integer
   var $author;  // Object (only if the user was registered & logged in)
   
-  function JSON_API_Comment($wp_comment = null) {
+  function __construct($wp_comment = null) {
     if ($wp_comment) {
       $this->import_wp_object($wp_comment);
     }

--- a/plugins/json-api/models/post.php
+++ b/plugins/json-api/models/post.php
@@ -27,7 +27,7 @@ class JSON_API_Post {
   var $thumbnail;       // String
   var $custom_fields;   // Object (included by using custom_fields query var)
   
-  function JSON_API_Post($wp_post = null) {
+  function __construct($wp_post = null) {
     if (!empty($wp_post)) {
       $this->import_wp_object($wp_post);
     }

--- a/plugins/json-api/models/tag.php
+++ b/plugins/json-api/models/tag.php
@@ -7,7 +7,7 @@ class JSON_API_Tag {
   var $title;       // String
   var $description; // String
   
-  function JSON_API_Tag($wp_tag = null) {
+  function __construct($wp_tag = null) {
     if ($wp_tag) {
       $this->import_wp_object($wp_tag);
     }


### PR DESCRIPTION
Fix the php warnings for a deprecated stuff .

" Methods with the same name as their class will not be constructors in a future version of PHP; JSON_API_**** has a deprecated constructor"